### PR TITLE
Fix database path to include basePath prefix

### DIFF
--- a/packages/web/components/providers/DatabaseProvider.tsx
+++ b/packages/web/components/providers/DatabaseProvider.tsx
@@ -244,8 +244,10 @@ export function DatabaseProvider({
   useEffect(() => {
     console.log('DatabaseProvider mount - isInitialized:', isInitialized, 'isLoading:', isLoading);
     if (!isInitialized && !isLoading) {
-      console.log('Attempting to load database from /data/sample.db');
-      loadDatabaseFn('/data/sample.db')
+      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+      const dbPath = `${basePath}/data/sample.db`;
+      console.log(`Attempting to load database from ${dbPath}`);
+      loadDatabaseFn(dbPath)
         .then(() => console.log('Database loaded successfully'))
         .catch((err) => console.error('Failed to load database:', err));
     }

--- a/packages/web/lib/db/database-context.tsx
+++ b/packages/web/lib/db/database-context.tsx
@@ -85,8 +85,10 @@ export function DatabaseProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     console.log('DatabaseContext mount - initializing database');
     if (!isInitialized && !isLoading) {
-      console.log('Loading database from /data/sample.db');
-      loadDatabase('/data/sample.db')
+      const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+      const dbPath = `${basePath}/data/sample.db`;
+      console.log(`Loading database from ${dbPath}`);
+      loadDatabase(dbPath)
         .then(() => console.log('Database loaded successfully'))
         .catch((err) => console.error('Failed to load database:', err));
     }


### PR DESCRIPTION
Updated database-context.tsx and DatabaseProvider.tsx to use NEXT_PUBLIC_BASE_PATH environment variable when loading the database file. This ensures /data/sample.db loads with the correct /fscrape prefix in production.

Fixes 404 error: https://neonwatty.github.io/data/sample.db

🤖 Generated with [Claude Code](https://claude.ai/code)