### PR TITLE
Fix Prettier formatting exclusion for SQL.js files

### DIFF
--- a/packages/web/.prettierignore
+++ b/packages/web/.prettierignore
@@ -24,6 +24,9 @@ coverage/
 *.sqlite
 *.sqlite3
 
+# SQL.js library files
+public/sql-js/
+
 # Environment
 .env
 .env.local


### PR DESCRIPTION
## Summary
- Exclude SQL.js library files from Prettier formatting checks
- Fixes deployment failure caused by format:check errors

## Changes  
- Added `public/sql-js/` to `.prettierignore`
- SQL.js library files don't follow project formatting standards

## Test plan
- [x] Local format:check passes with SQL.js files excluded
- [ ] Verify deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.ai/code)